### PR TITLE
Let Pinot startable to prefer using hostname over ip when instance id is not set by config

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -95,7 +95,7 @@ public class HelixBrokerStarter {
     _pinotHelixProperties = DefaultHelixBrokerConfig.getDefaultBrokerConf(pinotHelixProperties);
 
     if (brokerHost == null) {
-      if (_pinotHelixProperties.getBoolean(CommonConstants.Helix.Instance.PREFER_HOSTNAME_IN_DEFAULT_INSTANCD_ID_KEY, false)) {
+      if (_pinotHelixProperties.getBoolean(CommonConstants.Helix.PREFER_HOSTNAME_IN_DEFAULT_INSTANCD_ID_KEY, false)) {
         brokerHost = NetUtil.getHostnameOrAddress();
       } else {
         brokerHost = NetUtil.getHostAddress();

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -95,7 +95,11 @@ public class HelixBrokerStarter {
     _pinotHelixProperties = DefaultHelixBrokerConfig.getDefaultBrokerConf(pinotHelixProperties);
 
     if (brokerHost == null) {
-      brokerHost = NetUtil.getHostAddress();
+      if (_pinotHelixProperties.getBoolean(CommonConstants.Helix.Instance.PREFER_HOSTNAME_IN_DEFAULT_INSTANCD_ID_KEY, false)) {
+        brokerHost = NetUtil.getHostnameOrAddress();
+      } else {
+        brokerHost = NetUtil.getHostAddress();
+      }
     }
 
     final String brokerId = _pinotHelixProperties.getString(CommonConstants.Helix.Instance.INSTANCE_ID_KEY,

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -78,7 +78,6 @@ public class CommonConstants {
       public static final String INSTANCE_ID_KEY = "instanceId";
       public static final String DATA_DIR_KEY = "dataDir";
       public static final String ADMIN_PORT_KEY = "adminPort";
-      public static final String PREFER_HOSTNAME_IN_DEFAULT_INSTANCD_ID_KEY = "preferHostnameInDefaultInstanceId";
     }
 
     public enum TableType {
@@ -91,6 +90,8 @@ public class CommonConstants {
         return ServerType.REALTIME;
       }
     }
+
+    public static final String PREFER_HOSTNAME_IN_DEFAULT_INSTANCD_ID_KEY = "pinot.preferHostnameInDefaultInstanceId";
 
     public static final String KEY_OF_SERVER_NETTY_PORT = "pinot.server.netty.port";
     public static final int DEFAULT_SERVER_NETTY_PORT = 8098;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -78,6 +78,7 @@ public class CommonConstants {
       public static final String INSTANCE_ID_KEY = "instanceId";
       public static final String DATA_DIR_KEY = "dataDir";
       public static final String ADMIN_PORT_KEY = "adminPort";
+      public static final String PREFER_HOSTNAME_IN_DEFAULT_INSTANCD_ID_KEY = "preferHostnameInDefaultInstanceId";
     }
 
     public enum TableType {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -45,6 +45,7 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final String CONTROLLER_VIP_PROTOCOL = "controller.vip.protocol";
   private static final String CONTROLLER_HOST = "controller.host";
   private static final String CONTROLLER_PORT = "controller.port";
+  private static final String ENABLE_DEFAULT_HOSTNAME = "controller.enable.default.hostname";
   private static final String DATA_DIR = "controller.data.dir";
   // Potentially same as data dir if local
   private static final String LOCAL_TEMP_DIR = "controller.local.temp.dir";
@@ -240,6 +241,10 @@ public class ControllerConf extends PropertiesConfiguration {
     setProperty(CONTROLLER_HOST, host);
   }
 
+  public void setEnableDefaultHostname(boolean enableDefaultHostname) {
+    setProperty(ENABLE_DEFAULT_HOSTNAME, enableDefaultHostname);
+  }
+
   public void setControllerVipHost(String vipHost) {
     setProperty(CONTROLLER_VIP_HOST, vipHost);
   }
@@ -276,6 +281,10 @@ public class ControllerConf extends PropertiesConfiguration {
   // but we turn it on to true when we are sure that jersey api has no backward compatibility problems.
   public boolean isJerseyAdminPrimary() {
     return getBoolean(JERSEY_ADMIN_IS_PRIMARY, true);
+  }
+
+  public boolean enableDefaultHostname() {
+    return getBoolean(ENABLE_DEFAULT_HOSTNAME, false);
   }
 
   public String getHelixClusterName() {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ChaosMonkeyIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ChaosMonkeyIntegrationTest.java
@@ -52,6 +52,7 @@ public class ChaosMonkeyIntegrationTest {
 
   private Process runAdministratorCommand(String[] args) {
     String classpath = System.getProperty("java.class.path");
+    System.getProperties().setProperty("pinot.admin.system.exit", "false");
     List<String> completeArgs = new ArrayList<>();
     completeArgs.add("java");
     completeArgs.add("-Xms4G");

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -106,7 +106,7 @@ public class HelixServerStarter {
       _instanceId = _helixServerConfig.getString(CommonConstants.Server.CONFIG_OF_INSTANCE_ID);
     } else {
       String host = _helixServerConfig.getString(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST, _helixServerConfig
-          .getBoolean(CommonConstants.Helix.Instance.PREFER_HOSTNAME_IN_DEFAULT_INSTANCD_ID_KEY, false) ? NetUtil
+          .getBoolean(CommonConstants.Helix.PREFER_HOSTNAME_IN_DEFAULT_INSTANCD_ID_KEY, false) ? NetUtil
           .getHostnameOrAddress() : NetUtil.getHostAddress());
       int port = _helixServerConfig
           .getInt(CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT, CommonConstants.Helix.DEFAULT_SERVER_NETTY_PORT);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -105,8 +105,9 @@ public class HelixServerStarter {
     if (_helixServerConfig.containsKey(CommonConstants.Server.CONFIG_OF_INSTANCE_ID)) {
       _instanceId = _helixServerConfig.getString(CommonConstants.Server.CONFIG_OF_INSTANCE_ID);
     } else {
-      String host =
-          _helixServerConfig.getString(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST, NetUtil.getHostAddress());
+      String host = _helixServerConfig.getString(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST, _helixServerConfig
+          .getBoolean(CommonConstants.Helix.Instance.PREFER_HOSTNAME_IN_DEFAULT_INSTANCD_ID_KEY, false) ? NetUtil
+          .getHostnameOrAddress() : NetUtil.getHostAddress());
       int port = _helixServerConfig
           .getInt(CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT, CommonConstants.Helix.DEFAULT_SERVER_NETTY_PORT);
       _instanceId = CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE + host + "_" + port;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
@@ -91,8 +91,7 @@ public class PinotAdministrator {
     return _status;
   }
 
-  public void execute(String[] args)
-      throws Exception {
+  public void execute(String[] args) {
     try {
       CmdLineParser parser = new CmdLineParser(this);
       parser.parseArgument(args);
@@ -114,8 +113,7 @@ public class PinotAdministrator {
     }
   }
 
-  public static void main(String[] args)
-      throws Exception {
+  public static void main(String[] args) {
     PinotAdministrator pinotAdministrator = new PinotAdministrator();
     pinotAdministrator.execute(args);
     if (System.getProperties().getProperty("pinot.admin.system.exit", "false").equalsIgnoreCase("true")) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTableCommand.java
@@ -87,6 +87,11 @@ public class AddTableCommand extends AbstractBaseAdminCommand implements Command
     return this;
   }
 
+  public AddTableCommand setControllerHost(String controllerHost) {
+    _controllerHost = controllerHost;
+    return this;
+  }
+
   public AddTableCommand setControllerPort(String controllerPort) {
     _controllerPort = controllerPort;
     return this;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
@@ -192,7 +192,7 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
       return false;
     }
 
-    if (conf.getControllerHost() == null) {
+    if (!conf.enableDefaultHostname() && conf.getControllerHost() == null) {
       LOGGER.error("Error: missing hostname, please specify 'controller.host' property in config file.");
       return false;
     }


### PR DESCRIPTION
The reason for this change is that, for k8s deployment, StatefulSet could keep same pod hostname but not ip, so every restart will be treated as the old instance died forever and a new instances up joining the cluster.

Ideally this should be handled/set by internal startable wrapper which is not there yet.

Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
