### PR TITLE
Adding AST parser to PinotQuery insider BrokerRequest

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -27,10 +27,10 @@ import java.util.Set;
 import java.util.Stack;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.mutable.MutableInt;
+import org.apache.commons.math3.analysis.function.Exp;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
-import org.apache.pinot.common.request.FilterOperator;
 import org.apache.pinot.common.request.FilterQuery;
 import org.apache.pinot.common.request.FilterQueryMap;
 import org.apache.pinot.common.request.Function;
@@ -42,10 +42,12 @@ import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.request.Selection;
 import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
+import org.apache.pinot.pql.parsers.pql2.ast.PredicateAstNode;
 
 
 public class RequestUtils {
   private static String DELIMTER = "\t\t";
+
   private RequestUtils() {
   }
 
@@ -65,22 +67,29 @@ public class RequestUtils {
     request.setFilterSubQueryMap(mp);
   }
 
-
-  /**
-   * Generates thrift compliant filterQuery and populate it in the pinot query.
-   * @param filterQueryTree
-   * @param pinotQuery
-   */
-  public static void generateFilterFromTree(FilterQueryTree filterQueryTree, PinotQuery pinotQuery) {
-    Expression root = traverseFilterQuery(filterQueryTree);
-    pinotQuery.setFilterExpression(root);
+  public static Expression getIdentifierExpression(String identifier) {
+    Expression expression = new Expression(ExpressionType.IDENTIFIER);
+    expression.setIdentifier(new Identifier(identifier));
+    return expression;
   }
 
+  public static Expression getLiteralExpression(String literal) {
+    Expression expression = new Expression(ExpressionType.LITERAL);
+    expression.setLiteral(new Literal(literal));
+    return expression;
+  }
+
+  public static Expression getFunctionExpression(String operator) {
+    Expression expression = new Expression(ExpressionType.FUNCTION);
+    Function function = new Function(operator);
+    expression.setFunctionCall(function);
+    return expression;
+  }
 
   private static Expression traverseFilterQuery(FilterQueryTree tree) {
     Expression query = new Expression(ExpressionType.FUNCTION);
     final Function operator = new Function(tree.getOperator().name());
-    if (null != tree.getChildren()) {
+    if (null != tree.getChildren() && !tree.getChildren().isEmpty()) {
       // Not leaf node
       for (final FilterQueryTree c : tree.getChildren()) {
         operator.addToOperands(traverseFilterQuery(c));

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/Pql2Compiler.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/Pql2Compiler.java
@@ -39,6 +39,7 @@ import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.pql.parsers.pql2.ast.AstNode;
 import org.apache.pinot.pql.parsers.pql2.ast.BaseAstNode;
@@ -102,7 +103,10 @@ public class Pql2Compiler implements AbstractCompiler {
       validateHavingClause(rootNode);
 
       BrokerRequest brokerRequest = new BrokerRequest();
+      PinotQuery pinotQuery = new PinotQuery();
+      brokerRequest.setPinotQuery(pinotQuery);
       rootNode.updateBrokerRequest(brokerRequest);
+      rootNode.updatePinotQuery(pinotQuery);
       return brokerRequest;
     } catch (Pql2CompilationException e) {
       throw e;

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/AstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/AstNode.java
@@ -20,6 +20,7 @@ package org.apache.pinot.pql.parsers.pql2.ast;
 
 import java.util.List;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.PinotQuery;
 
 
 /**
@@ -42,7 +43,11 @@ public interface AstNode {
 
   void updateBrokerRequest(BrokerRequest brokerRequest);
 
+  void updatePinotQuery(PinotQuery pinotQuery);
+
   void sendBrokerRequestUpdateToChildren(BrokerRequest brokerRequest);
+
+  void sendPinotQueryUpdateToChildren(PinotQuery pinotQuery);
 
   String toString(int indent);
 }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/BaseAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/BaseAstNode.java
@@ -21,6 +21,7 @@ package org.apache.pinot.pql.parsers.pql2.ast;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.PinotQuery;
 
 
 /**
@@ -72,10 +73,23 @@ public abstract class BaseAstNode implements AstNode {
   }
 
   @Override
+  public void updatePinotQuery(PinotQuery pinotQuery) {
+  }
+
+  @Override
   public void sendBrokerRequestUpdateToChildren(BrokerRequest brokerRequest) {
     if (hasChildren()) {
       for (AstNode child : _children) {
         child.updateBrokerRequest(brokerRequest);
+      }
+    }
+  }
+
+  @Override
+  public void sendPinotQueryUpdateToChildren(PinotQuery pinotQuery) {
+    if (hasChildren()) {
+      for (AstNode child : _children) {
+        child.updatePinotQuery(pinotQuery);
       }
     }
   }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/BooleanOperatorAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/BooleanOperatorAstNode.java
@@ -20,6 +20,7 @@ package org.apache.pinot.pql.parsers.pql2.ast;
 
 import java.util.List;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.PinotQuery;
 
 
 /**
@@ -67,7 +68,16 @@ public enum BooleanOperatorAstNode implements AstNode {
   }
 
   @Override
+  public void updatePinotQuery(PinotQuery pinotQuery) {
+  }
+
+  @Override
   public void sendBrokerRequestUpdateToChildren(BrokerRequest brokerRequest) {
+    throw new AssertionError("Should not happen");
+  }
+
+  @Override
+  public void sendPinotQueryUpdateToChildren(PinotQuery pinotQuery) {
     throw new AssertionError("Should not happen");
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/GroupByAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/GroupByAstNode.java
@@ -18,8 +18,12 @@
  */
 package org.apache.pinot.pql.parsers.pql2.ast;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.GroupBy;
+import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 
 
@@ -35,5 +39,14 @@ public class GroupByAstNode extends BaseAstNode {
       groupBy.addToExpressions(TransformExpressionTree.getStandardExpression(child));
     }
     brokerRequest.setGroupBy(groupBy);
+  }
+
+  @Override
+  public void updatePinotQuery(PinotQuery pinotQuery) {
+    List<Expression> groupBy = new ArrayList<>();
+    for (AstNode child : getChildren()) {
+      groupBy.add(TransformExpressionTree.getExpression(child));
+    }
+    pinotQuery.setGroupByList(groupBy);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/HavingAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/HavingAstNode.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.pql.parsers.pql2.ast;
 
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.utils.request.RequestUtils;
 
 
@@ -30,5 +31,9 @@ public class HavingAstNode extends BaseAstNode {
   public void updateBrokerRequest(BrokerRequest brokerRequest) {
     PredicateAstNode predicateAstNode = (PredicateAstNode) getChildren().get(0);
     RequestUtils.generateFilterFromTree(predicateAstNode.buildHavingQueryTree(), brokerRequest);
+  }
+  @Override
+  public void updatePinotQuery(PinotQuery pinotQuery) {
+    // Skip HavingAstNode for now.
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/OptionAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/OptionAstNode.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.pql.parsers.pql2.ast;
 
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.pql.parsers.Pql2CompilationException;
 
 
@@ -53,5 +54,34 @@ public class OptionAstNode extends BaseAstNode {
     }
 
     brokerRequest.getQueryOptions().put(left, right);
+  }
+
+  @Override
+  public void updatePinotQuery(PinotQuery pinotQuery) {
+    if (getChildren().size() != 2) {
+      throw new Pql2CompilationException("Expected exactly two children for OptionAstNode");
+    }
+
+    String left;
+    AstNode leftNode = getChildren().get(0);
+
+    String right;
+    AstNode rightNode = getChildren().get(1);
+
+    if (leftNode instanceof IdentifierAstNode) {
+      left = ((IdentifierAstNode) leftNode).getExpression();
+    } else {
+      throw new Pql2CompilationException("Expected left child node of OptionAstNode to be an identifier");
+    }
+
+    if (rightNode instanceof IdentifierAstNode) {
+      right = ((IdentifierAstNode) rightNode).getExpression();
+    } else if (rightNode instanceof LiteralAstNode) {
+      right = ((LiteralAstNode) rightNode).getValueAsString();
+    } else {
+      throw new Pql2CompilationException("Right node of OptionAstNode is neither an identifier nor a literal");
+    }
+
+    pinotQuery.getQueryOptions().put(left, right);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/OptionsAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/OptionsAstNode.java
@@ -20,6 +20,7 @@ package org.apache.pinot.pql.parsers.pql2.ast;
 
 import java.util.HashMap;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.PinotQuery;
 
 
 /**
@@ -31,7 +32,14 @@ public class OptionsAstNode extends BaseAstNode {
     if (brokerRequest.getQueryOptions() == null) {
       brokerRequest.setQueryOptions(new HashMap<>());
     }
-
     sendBrokerRequestUpdateToChildren(brokerRequest);
+  }
+
+  @Override
+  public void updatePinotQuery(PinotQuery pinotQuery) {
+    if (pinotQuery.getQueryOptions() == null) {
+      pinotQuery.setQueryOptions(new HashMap<>());
+    }
+    sendPinotQueryUpdateToChildren(pinotQuery);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/OrderByAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/OrderByAstNode.java
@@ -18,7 +18,13 @@
  */
 package org.apache.pinot.pql.parsers.pql2.ast;
 
+import java.util.List;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.ExpressionType;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.Identifier;
+import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.request.Selection;
 import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.pql.parsers.Pql2CompilationException;
@@ -39,6 +45,28 @@ public class OrderByAstNode extends BaseAstNode {
         elem.setColumn(node.getColumn());
         elem.setIsAsc("asc".equalsIgnoreCase(node.getOrdering()));
         selections.addToSelectionSortSequence(elem);
+      } else {
+        throw new Pql2CompilationException("Child node of ORDER BY node is not an expression node");
+      }
+    }
+  }
+
+  @Override
+  public void updatePinotQuery(PinotQuery pinotQuery) {
+    for (AstNode astNode : getChildren()) {
+      if (astNode instanceof OrderByExpressionAstNode) {
+        OrderByExpressionAstNode node = (OrderByExpressionAstNode) astNode;
+        Expression orderByExpression = new Expression(ExpressionType.FUNCTION);
+        String ordering = "desc";
+        if ("asc".equalsIgnoreCase(node.getOrdering())) {
+          ordering = "asc";
+        }
+        Function orderByFunc = new Function(ordering);
+        Expression colExpr = new Expression(ExpressionType.IDENTIFIER);
+        colExpr.setIdentifier(new Identifier(node.getColumn()));
+        orderByFunc.addToOperands(colExpr);
+        orderByExpression.setFunctionCall(orderByFunc);
+        pinotQuery.addToOrderByList(orderByExpression);
       } else {
         throw new Pql2CompilationException("Child node of ORDER BY node is not an expression node");
       }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/OrderByAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/OrderByAstNode.java
@@ -18,15 +18,13 @@
  */
 package org.apache.pinot.pql.parsers.pql2.ast;
 
-import java.util.List;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.Expression;
-import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.Function;
-import org.apache.pinot.common.request.Identifier;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.request.Selection;
 import org.apache.pinot.common.request.SelectionSort;
+import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.pql.parsers.Pql2CompilationException;
 
 
@@ -56,16 +54,14 @@ public class OrderByAstNode extends BaseAstNode {
     for (AstNode astNode : getChildren()) {
       if (astNode instanceof OrderByExpressionAstNode) {
         OrderByExpressionAstNode node = (OrderByExpressionAstNode) astNode;
-        Expression orderByExpression = new Expression(ExpressionType.FUNCTION);
         String ordering = "desc";
         if ("asc".equalsIgnoreCase(node.getOrdering())) {
           ordering = "asc";
         }
-        Function orderByFunc = new Function(ordering);
-        Expression colExpr = new Expression(ExpressionType.IDENTIFIER);
-        colExpr.setIdentifier(new Identifier(node.getColumn()));
+        Expression orderByExpression = RequestUtils.getFunctionExpression(ordering);
+        Function orderByFunc = orderByExpression.getFunctionCall();
+        Expression colExpr = RequestUtils.getIdentifierExpression(node.getColumn());
         orderByFunc.addToOperands(colExpr);
-        orderByExpression.setFunctionCall(orderByFunc);
         pinotQuery.addToOrderByList(orderByExpression);
       } else {
         throw new Pql2CompilationException("Child node of ORDER BY node is not an expression node");

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/OutputColumnAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/OutputColumnAstNode.java
@@ -18,17 +18,12 @@
  */
 package org.apache.pinot.pql.parsers.pql2.ast;
 
-import java.util.ArrayList;
-import java.util.List;
-import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.Expression;
-import org.apache.pinot.common.request.ExpressionType;
-import org.apache.pinot.common.request.Function;
-import org.apache.pinot.common.request.Identifier;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.request.Selection;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
+import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.pql.parsers.Pql2CompilationException;
 
 
@@ -67,22 +62,15 @@ public class OutputColumnAstNode extends BaseAstNode {
         Expression functionExpr;
         if (node.getName().equalsIgnoreCase("count")) {
           // COUNT aggregation function always works on '*'
-          Expression expression;
-          expression = new Expression(ExpressionType.IDENTIFIER);
-          expression.setIdentifier(new Identifier("*"));
-          Function func = new Function("count");
-          func.addToOperands(expression);
-          functionExpr = new Expression(ExpressionType.FUNCTION);
-          functionExpr.setFunctionCall(func);
+          functionExpr = RequestUtils.getFunctionExpression("count");
+          functionExpr.getFunctionCall().addToOperands(RequestUtils.getIdentifierExpression("*"));
         } else {
           functionExpr = TransformExpressionTree.getExpression(astNode);
         }
         pinotQuery.addToSelectList(functionExpr);
       } else if (astNode instanceof IdentifierAstNode) {
         IdentifierAstNode node = (IdentifierAstNode) astNode;
-        Expression selectExpr = new Expression(ExpressionType.IDENTIFIER);
-        selectExpr.setIdentifier(new Identifier(node.getName()));
-        pinotQuery.addToSelectList(selectExpr);
+        pinotQuery.addToSelectList(RequestUtils.getIdentifierExpression(node.getName()));
       } else {
         throw new Pql2CompilationException("Output column is neither a function nor an identifier");
       }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/OutputColumnListAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/OutputColumnListAstNode.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.pql.parsers.pql2.ast;
 
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.PinotQuery;
 
 
 /**
@@ -43,5 +44,10 @@ public class OutputColumnListAstNode extends BaseAstNode {
   @Override
   public void updateBrokerRequest(BrokerRequest brokerRequest) {
     sendBrokerRequestUpdateToChildren(brokerRequest);
+  }
+
+  @Override
+  public void updatePinotQuery(PinotQuery pinotQuery) {
+    sendPinotQueryUpdateToChildren(pinotQuery);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/PredicateAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/PredicateAstNode.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.pql.parsers.pql2.ast;
 
+import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
 import org.apache.pinot.common.utils.request.HavingQueryTree;
 
@@ -36,6 +37,14 @@ public abstract class PredicateAstNode extends BaseAstNode {
    *
    */
   public abstract FilterQueryTree buildFilterQueryTree();
+
+  /**
+   * Create the query expression tree for the where clause
+   *
+   * @return
+   *
+   */
+  public abstract Expression buildFilterExpression();
 
   /**
    * Create the query tree for the having clause

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/PredicateParenthesisGroupAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/PredicateParenthesisGroupAstNode.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.pql.parsers.pql2.ast;
 
+import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
 import org.apache.pinot.common.utils.request.HavingQueryTree;
 
@@ -29,6 +30,11 @@ public class PredicateParenthesisGroupAstNode extends PredicateAstNode {
   @Override
   public FilterQueryTree buildFilterQueryTree() {
     return ((PredicateAstNode) getChildren().get(0)).buildFilterQueryTree();
+  }
+
+  @Override
+  public Expression buildFilterExpression() {
+    return ((PredicateAstNode) getChildren().get(0)).buildFilterExpression();
   }
 
   @Override

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/RegexpLikePredicateAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/RegexpLikePredicateAstNode.java
@@ -22,10 +22,13 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.FilterOperator;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
 import org.apache.pinot.common.utils.request.HavingQueryTree;
+import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.pql.parsers.Pql2CompilationException;
 
 
@@ -72,6 +75,19 @@ public class RegexpLikePredicateAstNode extends PredicateAstNode {
     FilterOperator filterOperator = FilterOperator.REGEXP_LIKE;
     List<String> value = Collections.singletonList(StringUtil.join(SEPERATOR, valueArray));
     return new FilterQueryTree(_identifier, value, filterOperator, null);
+  }
+
+  @Override
+  public Expression buildFilterExpression() {
+    if (_identifier == null) {
+      throw new Pql2CompilationException("REGEXP_LIKE predicate has no identifier");
+    }
+    final Expression expression = RequestUtils.getFunctionExpression(FilterOperator.REGEXP_LIKE.name());
+    expression.getFunctionCall().addToOperands(RequestUtils.getIdentifierExpression(_identifier));
+    for (AstNode astNode : getChildren()) {
+      expression.getFunctionCall().addToOperands(TransformExpressionTree.getExpression(astNode));
+    }
+    return expression;
   }
 
   @Override

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/SelectAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/SelectAstNode.java
@@ -19,7 +19,9 @@
 package org.apache.pinot.pql.parsers.pql2.ast;
 
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.DataSource;
 import org.apache.pinot.common.request.GroupBy;
+import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.request.QuerySource;
 import org.apache.pinot.common.request.Selection;
 import org.apache.pinot.pql.parsers.Pql2CompilationException;
@@ -142,6 +144,29 @@ public class SelectAstNode extends BaseAstNode {
     // Pinot quirk: if there is both a selection and an aggregation, remove the selection
     if (brokerRequest.getAggregationsInfoSize() != 0 && brokerRequest.isSetSelections()) {
       brokerRequest.setSelections(null);
+    }
+  }
+
+  @Override
+  public void updatePinotQuery(PinotQuery pinotQuery) {
+    // Set data source
+    final DataSource dataSource = new DataSource();
+    dataSource.setTableName(_resourceName);
+    pinotQuery.setDataSource(dataSource);
+    sendPinotQueryUpdateToChildren(pinotQuery);
+    if (_recordLimit != -1) {
+      pinotQuery.setLimit(_recordLimit);
+    }
+    if (_offset != -1) {
+      pinotQuery.setOffset(_offset);
+    }
+    if (pinotQuery.getGroupByListSize() > 0) {
+      if (_topN != -1) {
+        pinotQuery.setLimit(_topN);
+      } else {
+        // Pinot quirk: default to top 10
+        pinotQuery.setLimit(10);
+      }
     }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/StarColumnListAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/StarColumnListAstNode.java
@@ -21,6 +21,10 @@ package org.apache.pinot.pql.parsers.pql2.ast;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.ExpressionType;
+import org.apache.pinot.common.request.Identifier;
+import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.request.Selection;
 
 
@@ -35,5 +39,12 @@ public class StarColumnListAstNode extends BaseAstNode {
     modifiableList.add("*");
     selection.setSelectionColumns(modifiableList);
     brokerRequest.setSelections(selection);
+  }
+
+  @Override
+  public void updatePinotQuery(PinotQuery pinotQuery) {
+    Expression starExpr = new Expression(ExpressionType.IDENTIFIER);
+    starExpr.setIdentifier(new Identifier("*"));
+    pinotQuery.addToSelectList(starExpr);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/StarColumnListAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/StarColumnListAstNode.java
@@ -22,10 +22,9 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.Expression;
-import org.apache.pinot.common.request.ExpressionType;
-import org.apache.pinot.common.request.Identifier;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.request.Selection;
+import org.apache.pinot.common.utils.request.RequestUtils;
 
 
 /**
@@ -43,8 +42,7 @@ public class StarColumnListAstNode extends BaseAstNode {
 
   @Override
   public void updatePinotQuery(PinotQuery pinotQuery) {
-    Expression starExpr = new Expression(ExpressionType.IDENTIFIER);
-    starExpr.setIdentifier(new Identifier("*"));
+    Expression starExpr = RequestUtils.getIdentifierExpression("*");
     pinotQuery.addToSelectList(starExpr);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/WhereAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/WhereAstNode.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.pql.parsers.pql2.ast;
 
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.utils.request.RequestUtils;
 
 
@@ -30,5 +31,11 @@ public class WhereAstNode extends BaseAstNode {
   public void updateBrokerRequest(BrokerRequest brokerRequest) {
     PredicateAstNode predicateAstNode = (PredicateAstNode) getChildren().get(0);
     RequestUtils.generateFilterFromTree(predicateAstNode.buildFilterQueryTree(), brokerRequest);
+  }
+
+  @Override
+  public void updatePinotQuery(PinotQuery pinotQuery) {
+    PredicateAstNode predicateAstNode = (PredicateAstNode) getChildren().get(0);
+    RequestUtils.generateFilterFromTree(predicateAstNode.buildFilterQueryTree(), pinotQuery);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/WhereAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/WhereAstNode.java
@@ -36,6 +36,6 @@ public class WhereAstNode extends BaseAstNode {
   @Override
   public void updatePinotQuery(PinotQuery pinotQuery) {
     PredicateAstNode predicateAstNode = (PredicateAstNode) getChildren().get(0);
-    RequestUtils.generateFilterFromTree(predicateAstNode.buildFilterQueryTree(), pinotQuery);
+    pinotQuery.setFilterExpression(predicateAstNode.buildFilterExpression());
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/pql/parsers/Pql2CompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/pql/parsers/Pql2CompilerTest.java
@@ -272,12 +272,12 @@ public class Pql2CompilerTest {
     // Test PinotQuery
     List<Expression> selectFunctionList = brokerRequest.getPinotQuery().getSelectList();
     Assert.assertEquals(selectFunctionList.size(), 2);
-    Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "foo");
-    Assert.assertEquals(selectFunctionList.get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
+    Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getLiteral().getValue(), "foo");
+    Assert.assertEquals(selectFunctionList.get(1).getFunctionCall().getOperands().get(0).getLiteral().getValue(), "bar");
     List<Expression> groupbyList = brokerRequest.getPinotQuery().getGroupByList();
     Assert.assertEquals(groupbyList.size(), 2);
-    Assert.assertEquals(groupbyList.get(0).getIdentifier().getName(), "foo");
-    Assert.assertEquals(groupbyList.get(1).getIdentifier().getName(), "bar");
+    Assert.assertEquals(groupbyList.get(0).getLiteral().getValue(), "foo");
+    Assert.assertEquals(groupbyList.get(1).getLiteral().getValue(), "bar");
 
     // For UDF, string literal won't be treated as column but as LITERAL
     brokerRequest =
@@ -297,12 +297,12 @@ public class Pql2CompilerTest {
     Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "add");
     Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().size(), 2);
     Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "foo");
-    Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "bar");
+    Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1).getLiteral().getValue(), "bar");
     groupbyList = brokerRequest.getPinotQuery().getGroupByList();
     Assert.assertEquals(groupbyList.size(), 1);
     Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperator(), "sub");
     Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperands().size(), 2);
-    Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "foo");
+    Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperands().get(0).getLiteral().getValue(), "foo");
     Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "bar");
 
   }

--- a/pinot-common/src/test/java/org/apache/pinot/pql/parsers/Pql2CompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/pql/parsers/Pql2CompilerTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.FilterOperator;
 import org.apache.pinot.common.request.GroupBy;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
@@ -41,15 +42,23 @@ public class Pql2CompilerTest {
     BrokerRequest brokerRequest =
         COMPILER.compileToBrokerRequest("select * from vegetables where origin = 'Martha''s Vineyard'");
     Assert.assertEquals(brokerRequest.getFilterQuery().getValue().get(0), "Martha's Vineyard");
+    // Test PinotQuery
+    Assert.assertEquals(brokerRequest.getPinotQuery().getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getValue(), "Martha's Vineyard");
 
     brokerRequest = COMPILER.compileToBrokerRequest("select * from vegetables where origin = 'Martha\"\"s Vineyard'");
     Assert.assertEquals(brokerRequest.getFilterQuery().getValue().get(0), "Martha\"\"s Vineyard");
+    // Test PinotQuery
+    Assert.assertEquals(brokerRequest.getPinotQuery().getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getValue(), "Martha\"\"s Vineyard");
 
     brokerRequest = COMPILER.compileToBrokerRequest("select * from vegetables where origin = \"Martha\"\"s Vineyard\"");
     Assert.assertEquals(brokerRequest.getFilterQuery().getValue().get(0), "Martha\"s Vineyard");
+    // Test PinotQuery
+    Assert.assertEquals(brokerRequest.getPinotQuery().getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getValue(), "Martha\"s Vineyard");
 
     brokerRequest = COMPILER.compileToBrokerRequest("select * from vegetables where origin = \"Martha''s Vineyard\"");
     Assert.assertEquals(brokerRequest.getFilterQuery().getValue().get(0), "Martha''s Vineyard");
+    // Test PinotQuery
+    Assert.assertEquals(brokerRequest.getPinotQuery().getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getValue(), "Martha''s Vineyard");
   }
 
   @Test
@@ -94,6 +103,11 @@ public class Pql2CompilerTest {
     GroupBy groupBy = req.getGroupBy();
     Assert.assertTrue(groupBy.isSetTopN());
     Assert.assertEquals(expectedTopN, groupBy.getTopN());
+
+    // Test PinotQuery
+    Assert.assertTrue(req.getPinotQuery().isSetGroupByList());
+    Assert.assertTrue(req.getPinotQuery().isSetLimit());
+    Assert.assertEquals(expectedTopN, req.getPinotQuery().getLimit());
   }
 
   @Test
@@ -131,6 +145,9 @@ public class Pql2CompilerTest {
     BrokerRequest brokerRequest =
         COMPILER.compileToBrokerRequest("select * from vegetables where name != 'Brussels sprouts'");
     Assert.assertEquals(brokerRequest.getFilterQuery().getOperator(), FilterOperator.NOT);
+    // Test PinotQuery
+    Assert.assertEquals(brokerRequest.getPinotQuery().getFilterExpression().getFunctionCall().getOperator(), FilterOperator.NOT.name());
+
   }
 
   @Test
@@ -170,12 +187,19 @@ public class Pql2CompilerTest {
         COMPILER.compileToBrokerRequest("select * from vegetables where name != 'Brussels sprouts'");
     Assert.assertEquals(brokerRequest.getQueryOptionsSize(), 0);
     Assert.assertNull(brokerRequest.getQueryOptions());
+    // Test PinotQuery
+    Assert.assertEquals(brokerRequest.getPinotQuery().getQueryOptionsSize(), 0);
+    Assert.assertNull(brokerRequest.getPinotQuery().getQueryOptions());
 
     brokerRequest = COMPILER
         .compileToBrokerRequest("select * from vegetables where name != 'Brussels sprouts' OPTION (delicious=yes)");
     Assert.assertEquals(brokerRequest.getQueryOptionsSize(), 1);
     Assert.assertTrue(brokerRequest.getQueryOptions().containsKey("delicious"));
     Assert.assertEquals(brokerRequest.getQueryOptions().get("delicious"), "yes");
+    // Test PinotQuery
+    Assert.assertEquals(brokerRequest.getPinotQuery().getQueryOptionsSize(), 1);
+    Assert.assertTrue(brokerRequest.getPinotQuery().getQueryOptions().containsKey("delicious"));
+    Assert.assertEquals(brokerRequest.getPinotQuery().getQueryOptions().get("delicious"), "yes");
 
     brokerRequest = COMPILER.compileToBrokerRequest(
         "select * from vegetables where name != 'Brussels sprouts' OPTION (delicious=yes, foo=1234, bar='potato')");
@@ -184,6 +208,12 @@ public class Pql2CompilerTest {
     Assert.assertEquals(brokerRequest.getQueryOptions().get("delicious"), "yes");
     Assert.assertEquals(brokerRequest.getQueryOptions().get("foo"), "1234");
     Assert.assertEquals(brokerRequest.getQueryOptions().get("bar"), "potato");
+    // Test PinotQuery
+    Assert.assertEquals(brokerRequest.getPinotQuery().getQueryOptionsSize(), 3);
+    Assert.assertTrue(brokerRequest.getPinotQuery().getQueryOptions().containsKey("delicious"));
+    Assert.assertEquals(brokerRequest.getPinotQuery().getQueryOptions().get("delicious"), "yes");
+    Assert.assertEquals(brokerRequest.getPinotQuery().getQueryOptions().get("foo"), "1234");
+    Assert.assertEquals(brokerRequest.getPinotQuery().getQueryOptions().get("bar"), "potato");
 
     brokerRequest = COMPILER.compileToBrokerRequest(
         "select * from vegetables where name != 'Brussels sprouts' OPTION (delicious=yes) option(foo=1234) option(bar='potato')");
@@ -192,6 +222,12 @@ public class Pql2CompilerTest {
     Assert.assertEquals(brokerRequest.getQueryOptions().get("delicious"), "yes");
     Assert.assertEquals(brokerRequest.getQueryOptions().get("foo"), "1234");
     Assert.assertEquals(brokerRequest.getQueryOptions().get("bar"), "potato");
+    // Test PinotQuery
+    Assert.assertEquals(brokerRequest.getPinotQuery().getQueryOptionsSize(), 3);
+    Assert.assertTrue(brokerRequest.getPinotQuery().getQueryOptions().containsKey("delicious"));
+    Assert.assertEquals(brokerRequest.getPinotQuery().getQueryOptions().get("delicious"), "yes");
+    Assert.assertEquals(brokerRequest.getPinotQuery().getQueryOptions().get("foo"), "1234");
+    Assert.assertEquals(brokerRequest.getPinotQuery().getQueryOptions().get("bar"), "potato");
   }
 
   @Test
@@ -209,6 +245,11 @@ public class Pql2CompilerTest {
         Collections.singletonList("attributes.address_city"));
     Assert.assertEquals(brokerRequest.getHavingFilterQuery().getAggregationInfo().getAggregationParams().get("column"),
         "attributes.age");
+
+    // Test PinotQuery
+    Assert.assertEquals(brokerRequest.getPinotQuery().getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+        "attributes.age");
+    Assert.assertEquals(brokerRequest.getPinotQuery().getGroupByList().get(0).getIdentifier().getName(),"attributes.address_city");
   }
 
   @Test
@@ -228,6 +269,16 @@ public class Pql2CompilerTest {
     Assert.assertEquals(expressions.get(0), "foo");
     Assert.assertEquals(expressions.get(1), "bar");
 
+    // Test PinotQuery
+    List<Expression> selectFunctionList = brokerRequest.getPinotQuery().getSelectList();
+    Assert.assertEquals(selectFunctionList.size(), 2);
+    Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "foo");
+    Assert.assertEquals(selectFunctionList.get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
+    List<Expression> groupbyList = brokerRequest.getPinotQuery().getGroupByList();
+    Assert.assertEquals(groupbyList.size(), 2);
+    Assert.assertEquals(groupbyList.get(0).getIdentifier().getName(), "foo");
+    Assert.assertEquals(groupbyList.get(1).getIdentifier().getName(), "bar");
+
     // For UDF, string literal won't be treated as column but as LITERAL
     brokerRequest =
         COMPILER.compileToBrokerRequest("SELECT SUM(ADD(foo, 'bar')) FROM table GROUP BY SUB(\"foo\", bar)");
@@ -237,5 +288,22 @@ public class Pql2CompilerTest {
     expressions = brokerRequest.getGroupBy().getExpressions();
     Assert.assertEquals(expressions.size(), 1);
     Assert.assertEquals(expressions.get(0), "sub('foo',bar)");
+
+    // Test PinotQuery
+    selectFunctionList = brokerRequest.getPinotQuery().getSelectList();
+    Assert.assertEquals(selectFunctionList.size(), 1);
+    Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperator(), "sum");
+    Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().size(), 1);
+    Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "add");
+    Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().size(), 2);
+    Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "foo");
+    Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "bar");
+    groupbyList = brokerRequest.getPinotQuery().getGroupByList();
+    Assert.assertEquals(groupbyList.size(), 1);
+    Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperator(), "sub");
+    Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperands().size(), 2);
+    Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "foo");
+    Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "bar");
+
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/request/BrokerRequestSerializationTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/request/BrokerRequestSerializationTest.java
@@ -22,10 +22,17 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.DataSource;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.FilterOperator;
 import org.apache.pinot.common.request.FilterQuery;
 import org.apache.pinot.common.request.FilterQueryMap;
+import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.GroupBy;
+import org.apache.pinot.common.request.Identifier;
+import org.apache.pinot.common.request.Literal;
+import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.request.QuerySource;
 import org.apache.pinot.common.request.QueryType;
 import org.apache.pinot.common.request.Selection;
@@ -42,6 +49,176 @@ public class BrokerRequestSerializationTest {
   public static void testSerialization()
       throws TException {
     BrokerRequest req = new BrokerRequest();
+
+    // Populate Query Type
+    QueryType type = new QueryType();
+    type.setHasAggregation(true);
+    type.setHasFilter(true);
+    type.setHasSelection(true);
+    type.setHasGroup_by(true);
+    req.setQueryType(type);
+
+    // Populate Query source
+    QuerySource s = new QuerySource();
+    s.setTableName("dummy");
+    req.setQuerySource(s);
+
+    req.setDuration("dummy");
+    req.setTimeInterval("dummy");
+
+    //Populate Group-By
+    GroupBy groupBy = new GroupBy();
+    List<String> columns = new ArrayList<String>();
+    columns.add("dummy1");
+    columns.add("dummy2");
+    groupBy.setColumns(columns);
+    groupBy.setTopN(100);
+    req.setGroupBy(groupBy);
+
+    //Populate Selections
+    Selection sel = new Selection();
+    sel.setSize(1);
+    SelectionSort s2 = new SelectionSort();
+    s2.setColumn("dummy1");
+    s2.setIsAsc(true);
+    sel.addToSelectionSortSequence(s2);
+    sel.addToSelectionColumns("dummy1");
+    req.setSelections(sel);
+
+    //Populate FilterQuery
+    FilterQuery q1 = new FilterQuery();
+    q1.setId(1);
+    q1.setColumn("dummy1");
+    q1.addToValue("dummy1");
+    q1.addToNestedFilterQueryIds(2);
+    q1.setOperator(FilterOperator.AND);
+    FilterQuery q2 = new FilterQuery();
+    q2.setId(2);
+    q2.setColumn("dummy2");
+    q2.addToValue("dummy2");
+    q2.setOperator(FilterOperator.AND);
+
+    FilterQueryMap map = new FilterQueryMap();
+    map.putToFilterQueryMap(1, q1);
+    map.putToFilterQueryMap(2, q2);
+    req.setFilterQuery(q1);
+    req.setFilterSubQueryMap(map);
+
+    //Populate Aggregations
+    AggregationInfo agg = new AggregationInfo();
+    agg.setAggregationType("dummy1");
+    agg.putToAggregationParams("key1", "dummy1");
+    req.addToAggregationsInfo(agg);
+
+    TSerializer normalSerializer = new TSerializer();
+    TSerializer compactSerializer = new TSerializer(new TCompactProtocol.Factory());
+    normalSerializer.serialize(req);
+    compactSerializer.serialize(req);
+
+//    int numRequests = 100000;
+//    TimerContext t = MetricsHelper.startTimer();
+//    TSerializer serializer = new TSerializer(new TCompactProtocol.Factory());
+//    //TSerializer serializer = new TSerializer();
+//    //Compact : Size 183 , Serialization Latency : 0.03361ms
+//    // Normal : Size 385 , Serialization Latency : 0.01144ms
+//
+//    for (int i = 0; i < numRequests; i++) {
+//      try {
+//        serializer.serialize(req);
+//        //System.out.println(s3.length);
+//        //break;
+//      } catch (TException e) {
+//        e.printStackTrace();
+//      }
+//    }
+//    t.stop();
+//    System.out.println("Latency is :" + (t.getLatencyMs() / (float) numRequests));
+  }
+
+
+  @Test
+  public static void testSerializationWithPinotQuery()
+      throws TException {
+    BrokerRequest req = new BrokerRequest();
+
+    // START Set PinotQuery
+    PinotQuery pinotQuery = new PinotQuery();
+
+    // Populate Query source
+    DataSource dataSource = new DataSource();
+    dataSource.setTableName("dummy");
+    pinotQuery.setDataSource(dataSource);
+
+    //Populate Group-By
+
+    List<Expression> groupByList = new ArrayList<>();
+    Expression groupByCol1Expr = new Expression(ExpressionType.IDENTIFIER);
+    groupByCol1Expr.setIdentifier(new Identifier("dummy1"));
+    groupByList.add(groupByCol1Expr);
+    Expression groupByCol2Expr = new Expression(ExpressionType.IDENTIFIER);
+    groupByCol2Expr.setIdentifier(new Identifier("dummy2"));
+    groupByList.add(groupByCol2Expr);
+    pinotQuery.setGroupByList(groupByList);
+    pinotQuery.setLimit(100);
+
+    //Populate Selections
+    Expression s1 = new Expression(ExpressionType.IDENTIFIER);
+    s1.setIdentifier(new Identifier("dummy1"));
+    pinotQuery.addToSelectList(s1);
+
+    //Populate OrderBy
+    Expression ascExpr = new Expression(ExpressionType.FUNCTION);
+    Function ascFunc = new Function("asc");
+    Expression col1Expr = new Expression(ExpressionType.IDENTIFIER);
+    col1Expr.setIdentifier(new Identifier("dummy1"));
+    ascFunc.addToOperands(col1Expr);
+    ascExpr.setFunctionCall(ascFunc);
+    pinotQuery.addToOrderByList(ascExpr);
+
+    //Populate FilterQuery
+    Expression filter = new Expression(ExpressionType.FUNCTION);
+    Function andOps = new Function(FilterOperator.AND.name());
+
+    Expression filterExpr1 = new Expression(ExpressionType.FUNCTION);
+    Function funcExpr1 = new Function(FilterOperator.EQUALITY.name());
+    Expression filter1Left = new Expression(ExpressionType.IDENTIFIER);
+    filter1Left.setIdentifier(new Identifier("dummy1"));
+    funcExpr1.addToOperands(filter1Left);
+    Expression filter1Right = new Expression(ExpressionType.LITERAL);
+    filter1Right.setLiteral(new Literal("dummy1"));
+    funcExpr1.addToOperands(filter1Right);
+    filterExpr1.setFunctionCall(funcExpr1);
+    andOps.addToOperands(filterExpr1);
+
+
+    Expression filterExpr2 = new Expression(ExpressionType.FUNCTION);
+    Function funcExpr2 = new Function(FilterOperator.EQUALITY.name());
+    Expression filter2Left = new Expression(ExpressionType.IDENTIFIER);
+    filter2Left.setIdentifier(new Identifier("dummy2"));
+    funcExpr2.addToOperands(filter2Left);
+    Expression filter2Right = new Expression(ExpressionType.LITERAL);
+    filter2Right.setLiteral(new Literal("dummy2"));
+    funcExpr2.addToOperands(filter2Right);
+    filterExpr2.setFunctionCall(funcExpr2);
+    andOps.addToOperands(filterExpr2);
+
+    filter.setFunctionCall(andOps);
+    pinotQuery.setFilterExpression(filter);
+
+
+    //Populate Aggregations
+    Expression aggExpr = new Expression(ExpressionType.FUNCTION);
+    Function aggFunc = new Function("dummy1");
+    Expression aggCol = new Expression(ExpressionType.IDENTIFIER);
+    aggCol.setIdentifier(new Identifier("dummy1"));
+    aggFunc.addToOperands(aggCol);
+    aggExpr.setFunctionCall(aggFunc);
+    pinotQuery.addToSelectList(aggExpr);
+
+    req.setPinotQuery(pinotQuery);
+
+    // END Set PinotQuery
+
 
     // Populate Query Type
     QueryType type = new QueryType();


### PR DESCRIPTION
Per issue: https://github.com/winedepot/pinot/issues/14. 
This PR will traverse all the PQL parsed AST nodes and update PinotQuery. 
Similar to `updateBrokerRequest`, this PR implements `updatePinotQuery` to populate all the required fields of `pinotQuery` then put pinotQuery into BrokerRequest.

Test cases cover existing PQLs conversion as well as the correctness of PinotQuery fields setup
