### PR TITLE
Adding support for udfs in Selection

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/OutputColumnAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/OutputColumnAstNode.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.pql.parsers.pql2.ast;
 
+import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.PinotQuery;
@@ -38,6 +39,7 @@ public class OutputColumnAstNode extends BaseAstNode {
       if (astNode instanceof FunctionCallAstNode) {
         FunctionCallAstNode node = (FunctionCallAstNode) astNode;
         brokerRequest.addToAggregationsInfo(node.buildAggregationInfo());
+
       } else if (astNode instanceof IdentifierAstNode) {
         Selection selection = brokerRequest.getSelections();
         if (selection == null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOperator.java
@@ -1,15 +1,19 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements.  See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with the License.  You may obtain
- * a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied.  See the License for the specific language governing permissions and limitations
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
  * under the License.
  */
 package org.apache.pinot.core.operator.query;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOperator.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.operator.query;
 
 import java.io.Serializable;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -30,6 +31,7 @@ import org.apache.pinot.common.request.Selection;
 import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.primitive.ByteArray;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.BaseOperator;
@@ -170,6 +172,7 @@ public class SelectionOperator extends BaseOperator<IntermediateResultsBlock> {
                 ret = ((Double) v2).compareTo((Double) v1);
               }
               break;
+            case BOOLEAN:
             case STRING:
               if (!selectionSort.isIsAsc()) {
                 ret = ((String) v1).compareTo((String) v2);
@@ -177,6 +180,12 @@ public class SelectionOperator extends BaseOperator<IntermediateResultsBlock> {
                 ret = ((String) v2).compareTo((String) v1);
               }
               break;
+            case BYTES:
+              if (!selectionSort.isIsAsc()) {
+                ret = ByteArray.compare((byte[]) v1, (byte[]) v2);
+              } else {
+                ret = ByteArray.compare((byte[]) v2, (byte[]) v1);
+              }
             default:
               break;
           }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOperator.java
@@ -1,19 +1,15 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements.  See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the License.  You may obtain
+ * a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
  * under the License.
  */
 package org.apache.pinot.core.operator.query;
@@ -196,33 +192,27 @@ public class SelectionOperator extends BaseOperator<IntermediateResultsBlock> {
     int numDocsScanned = 0;
 
     TransformBlock transformBlock;
-    if (_orderByExpressions.isEmpty()) {
-      while ((transformBlock = _transformOperator.nextBlock()) != null) {
-        for (int i = 0; i < _expressions.size(); i++) {
-          TransformExpressionTree expression = _expressions.get(i);
-          _blockValSets[i] = transformBlock.getBlockValueSet(expression);
-        }
-        TransformBlockDataFetcher dataFetcher;
-        dataFetcher = new TransformBlockDataFetcher(_blockValSets, _dictionaries,
-            _expressionResultMetadata);
+    boolean selectionOnly = _orderByExpressions.isEmpty();
+    while ((transformBlock = _transformOperator.nextBlock()) != null) {
+      for (int i = 0; i < _expressions.size(); i++) {
+        TransformExpressionTree expression = _expressions.get(i);
+        _blockValSets[i] = transformBlock.getBlockValueSet(expression);
+      }
+      TransformBlockDataFetcher dataFetcher;
+      dataFetcher = new TransformBlockDataFetcher(_blockValSets, _dictionaries,
+          _expressionResultMetadata);
+      if (!selectionOnly) {
         int docId = 0;
         while (_rowEvents.size() < _limit && docId < transformBlock.getNumDocs()) {
           Serializable[] row = dataFetcher.getRow(docId);
           _rowEvents.add(row);
+          docId = docId + 1;
         }
         if (_rowEvents.size() >= _limit) {
           break;
         }
-      }
-    } else {
-      while ((transformBlock = _transformOperator.nextBlock()) != null) {
-        for (int i = 0; i < _expressions.size(); i++) {
-          TransformExpressionTree expression = _expressions.get(i);
-          _blockValSets[i] = transformBlock.getBlockValueSet(expression);
-        }
-        TransformBlockDataFetcher dataFetcher;
-        dataFetcher = new TransformBlockDataFetcher(_blockValSets, _dictionaries,
-            _expressionResultMetadata);
+      } else {
+        //Selection + orderby
         int docId = 0;
         while (docId < transformBlock.getNumDocs()) {
           Serializable[] row = dataFetcher.getRow(docId);
@@ -233,6 +223,7 @@ public class SelectionOperator extends BaseOperator<IntermediateResultsBlock> {
             _priorityQueue.poll();
             _priorityQueue.offer(row);
           }
+          docId = docId + 1;
         }
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOperator.java
@@ -1,0 +1,269 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.query;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.PriorityQueue;
+import org.apache.pinot.common.data.FieldSpec.DataType;
+import org.apache.pinot.common.request.Selection;
+import org.apache.pinot.common.request.SelectionSort;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.indexsegment.IndexSegment;
+import org.apache.pinot.core.operator.BaseOperator;
+import org.apache.pinot.core.operator.ExecutionStatistics;
+import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
+import org.apache.pinot.core.operator.blocks.TransformBlock;
+import org.apache.pinot.core.operator.transform.TransformBlockDataFetcher;
+import org.apache.pinot.core.operator.transform.TransformOperator;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.core.segment.index.readers.Dictionary;
+
+
+/**
+ * This SelectionOnlyOperator will take care of applying a selection query to one IndexSegment.
+ * nextBlock() will return an IntermediateResultBlock for the given IndexSegment.
+ */
+public class SelectionOperator extends BaseOperator<IntermediateResultsBlock> {
+
+  private static final String OPERATOR_NAME = "SelectionOnlyOperator";
+
+  private final IndexSegment _indexSegment;
+  private final TransformOperator _transformOperator;
+  private final DataSchema _dataSchema;
+  private final BlockValSet[] _blockValSets;
+  private final int _limit;
+  private Selection _selection;
+  private final int _offset;
+  private final int _maxRows;
+  private final Collection<Serializable[]> _rowEvents;
+  private final List<TransformExpressionTree> _expressions;
+  private final List<TransformExpressionTree> _selectExpressions;
+  private final List<TransformExpressionTree> _orderByExpressions;
+  private final List<Integer> _orderByIndices;
+  private final TransformResultMetadata[] _expressionResultMetadata;
+  private final Dictionary[] _dictionaries;
+  private final PriorityQueue<Serializable[]> _priorityQueue;
+
+  private ExecutionStatistics _executionStatistics;
+
+  public SelectionOperator(IndexSegment indexSegment, Selection selection,
+      TransformOperator transformOperator) {
+    _indexSegment = indexSegment;
+    _offset = selection.getOffset();
+    _limit = selection.getSize();
+    _selection = selection;
+    _maxRows = _offset + _limit;
+    _transformOperator = transformOperator;
+    _expressions = _transformOperator.getExpressions();
+
+    List<String> selectColumns = selection.getSelectionColumns();
+    if (selectColumns.size() == 1 && selectColumns.get(0).equals("*")) {
+      selectColumns = new LinkedList<>(indexSegment.getPhysicalColumnNames());
+    }
+
+    List<String> orderByColumns = selection.getSelectionColumns();
+    if (selection.getSelectionSortSequence() != null) {
+      for (SelectionSort selectionSort : selection.getSelectionSortSequence()) {
+        String expression = selectionSort.getColumn();
+        orderByColumns.add(expression);
+      }
+    }
+    _selectExpressions = new ArrayList<>();
+    _orderByExpressions = new ArrayList<>();
+    _orderByIndices = new ArrayList<>();
+    for (int i = 0; i < _expressions.size(); i++) {
+      TransformExpressionTree expression = _expressions.get(i);
+      if (selectColumns.contains(expression.toString())) {
+        _selectExpressions.add(expression);
+      }
+      if (orderByColumns.contains(expression.toString())) {
+        _orderByExpressions.add(expression);
+        _orderByIndices.add(i);
+      }
+    }
+    _blockValSets = new BlockValSet[_expressions.size()];
+    _expressionResultMetadata = new TransformResultMetadata[_expressions.size()];
+    _dictionaries = new Dictionary[_expressions.size()];
+    DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[_expressions
+        .size()];
+    String[] columnNames = new String[_expressions.size()];
+    for (int i = 0; i < _expressions.size(); i++) {
+      TransformExpressionTree expression = _expressions.get(i);
+      _expressionResultMetadata[i] = _transformOperator.getResultMetadata(expression);
+      columnDataTypes[i] = DataSchema.ColumnDataType
+          .fromDataType(_expressionResultMetadata[i].getDataType(),
+              _expressionResultMetadata[i].isSingleValue());
+      columnNames[i] = expression.toString();
+      if (_expressionResultMetadata[i].hasDictionary()) {
+        _dictionaries[i] = _transformOperator.getDictionary(expression);
+      }
+    }
+    _dataSchema = new DataSchema(columnNames, columnDataTypes);
+    Comparator<Serializable[]> comparator = getStrictComparator();
+    _priorityQueue = new PriorityQueue<>(_maxRows, comparator);
+    _rowEvents = new ArrayList<>();
+  }
+
+  private Comparator<Serializable[]> getStrictComparator() {
+    return new Comparator<Serializable[]>() {
+      @Override
+      public int compare(Serializable[] o1, Serializable[] o2) {
+        List<SelectionSort> sortSequence = _selection.getSelectionSortSequence();
+        int numSortColumns = sortSequence.size();
+        for (int i = 0; i < numSortColumns; i++) {
+          int ret = 0;
+          SelectionSort selectionSort = sortSequence.get(i);
+          Serializable v1 = o1[i];
+          Serializable v2 = o2[i];
+          int index = _orderByIndices.get(i);
+          DataType dataType = _expressionResultMetadata[index].getDataType();
+          // Only compare single-value columns.
+          switch (dataType) {
+            case INT:
+              if (!selectionSort.isIsAsc()) {
+                ret = ((Integer) v1).compareTo((Integer) v2);
+              } else {
+                ret = ((Integer) v2).compareTo((Integer) v1);
+              }
+              break;
+            case LONG:
+              if (!selectionSort.isIsAsc()) {
+                ret = ((Long) v1).compareTo((Long) v2);
+              } else {
+                ret = ((Long) v2).compareTo((Long) v1);
+              }
+              break;
+            case FLOAT:
+              if (!selectionSort.isIsAsc()) {
+                ret = ((Float) v1).compareTo((Float) v2);
+              } else {
+                ret = ((Float) v2).compareTo((Float) v1);
+              }
+              break;
+            case DOUBLE:
+              if (!selectionSort.isIsAsc()) {
+                ret = ((Double) v1).compareTo((Double) v2);
+              } else {
+                ret = ((Double) v2).compareTo((Double) v1);
+              }
+              break;
+            case STRING:
+              if (!selectionSort.isIsAsc()) {
+                ret = ((String) v1).compareTo((String) v2);
+              } else {
+                ret = ((String) v2).compareTo((String) v1);
+              }
+              break;
+            default:
+              break;
+          }
+
+          if (ret != 0) {
+            return ret;
+          }
+        }
+        return 0;
+      }
+    };
+
+  }
+
+  @Override
+  protected IntermediateResultsBlock getNextBlock() {
+    int numDocsScanned = 0;
+
+    TransformBlock transformBlock;
+    if (_orderByExpressions.isEmpty()) {
+      while ((transformBlock = _transformOperator.nextBlock()) != null) {
+        for (int i = 0; i < _expressions.size(); i++) {
+          TransformExpressionTree expression = _expressions.get(i);
+          _blockValSets[i] = transformBlock.getBlockValueSet(expression);
+        }
+        TransformBlockDataFetcher dataFetcher;
+        dataFetcher = new TransformBlockDataFetcher(_blockValSets, _dictionaries,
+            _expressionResultMetadata);
+        int docId = 0;
+        while (_rowEvents.size() < _limit && docId < transformBlock.getNumDocs()) {
+          Serializable[] row = dataFetcher.getRow(docId);
+          _rowEvents.add(row);
+        }
+        if (_rowEvents.size() >= _limit) {
+          break;
+        }
+      }
+    } else {
+      while ((transformBlock = _transformOperator.nextBlock()) != null) {
+        for (int i = 0; i < _expressions.size(); i++) {
+          TransformExpressionTree expression = _expressions.get(i);
+          _blockValSets[i] = transformBlock.getBlockValueSet(expression);
+        }
+        TransformBlockDataFetcher dataFetcher;
+        dataFetcher = new TransformBlockDataFetcher(_blockValSets, _dictionaries,
+            _expressionResultMetadata);
+        int docId = 0;
+        while (docId < transformBlock.getNumDocs()) {
+          Serializable[] row = dataFetcher.getRow(docId);
+          _priorityQueue.add(row);
+          if (_priorityQueue.size() < _maxRows) {
+            _priorityQueue.add(row);
+          } else if (_priorityQueue.comparator().compare(_priorityQueue.peek(), row) < 0) {
+            _priorityQueue.poll();
+            _priorityQueue.offer(row);
+          }
+        }
+      }
+    }
+
+    // Create execution statistics.
+    long numEntriesScannedInFilter = _transformOperator.getExecutionStatistics()
+        .getNumEntriesScannedInFilter();
+    long numEntriesScannedPostFilter = numDocsScanned * _transformOperator.getNumColumnsProjected();
+    long numTotalRawDocs = _indexSegment.getSegmentMetadata().getTotalRawDocs();
+    _executionStatistics =
+        new ExecutionStatistics(numDocsScanned, numEntriesScannedInFilter,
+            numEntriesScannedPostFilter,
+            numTotalRawDocs);
+    if (_orderByExpressions.isEmpty()) {
+      return new IntermediateResultsBlock(_dataSchema, _rowEvents);
+    } else {
+      return new IntermediateResultsBlock(_dataSchema, _priorityQueue);
+    }
+  }
+
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
+  }
+
+  @Override
+  public ExecutionStatistics getExecutionStatistics() {
+    return _executionStatistics;
+  }
+}
+
+
+

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/TransformBlockDataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/TransformBlockDataFetcher.java
@@ -1,15 +1,19 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements.  See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with the License.  You may obtain
- * a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied.  See the License for the specific language governing permissions and limitations
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
  * under the License.
  */
 package org.apache.pinot.core.operator.transform;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/TransformBlockDataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/TransformBlockDataFetcher.java
@@ -1,19 +1,15 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements.  See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the License.  You may obtain
+ * a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
  * under the License.
  */
 package org.apache.pinot.core.operator.transform;
@@ -53,17 +49,8 @@ public class TransformBlockDataFetcher {
       TransformResultMetadata expressionResultMetadata) {
     if (expressionResultMetadata.hasDictionary()) {
       if (expressionResultMetadata.isSingleValue()) {
-        switch (expressionResultMetadata.getDataType()) {
-          case INT:
-          case LONG:
-          case FLOAT:
-          case DOUBLE:
-          case BOOLEAN:
-          case STRING:
-          case BYTES:
-            return new DictionaryBasedSVValueFetcher(dictionary,
-                blockValSet.getDictionaryIdsSV(), expressionResultMetadata.getDataType());
-        }
+        return new DictionaryBasedSVValueFetcher(dictionary,
+            blockValSet.getDictionaryIdsSV(), expressionResultMetadata.getDataType());
       } else {
         switch (expressionResultMetadata.getDataType()) {
           case INT:

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/TransformBlockDataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/TransformBlockDataFetcher.java
@@ -1,0 +1,348 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform;
+
+import java.io.Serializable;
+import org.apache.pinot.common.data.FieldSpec;
+import org.apache.pinot.common.data.FieldSpec.DataType;
+import org.apache.pinot.common.request.transform.TransformExpressionTree;
+import org.apache.pinot.common.utils.primitive.ByteArray;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.segment.index.readers.Dictionary;
+
+public class TransformBlockDataFetcher {
+
+
+  private final Fetcher[] _fetchers;
+
+  public TransformBlockDataFetcher(BlockValSet[] blockValSets, Dictionary[] dictionaries,
+      TransformResultMetadata[] expressionResultMetadata) {
+    _fetchers = new Fetcher[blockValSets.length];
+    for (int i = 0; i < blockValSets.length; i++) {
+      _fetchers[i] = createFetcher(blockValSets[i], dictionaries[i],
+          expressionResultMetadata[i]);
+    }
+  }
+
+  public Serializable[] getRow(int docId) {
+    Serializable[] row = new Serializable[_fetchers.length];
+    for (int i = 0; i < _fetchers.length; i++) {
+      row[i] = _fetchers[i].getValue(docId);
+    }
+    return row;
+  }
+
+  Fetcher createFetcher(BlockValSet blockValSet,
+      Dictionary dictionary,
+      TransformResultMetadata expressionResultMetadata) {
+    if (expressionResultMetadata.hasDictionary()) {
+      if (expressionResultMetadata.isSingleValue()) {
+        switch (expressionResultMetadata.getDataType()) {
+          case INT:
+          case LONG:
+          case FLOAT:
+          case DOUBLE:
+          case BOOLEAN:
+          case STRING:
+          case BYTES:
+            return new DictionaryBasedSVValueFetcher(dictionary,
+                blockValSet.getDictionaryIdsSV(), expressionResultMetadata.getDataType());
+        }
+      } else {
+        switch (expressionResultMetadata.getDataType()) {
+          case INT:
+            return new DictionaryBasedMVIntValueFetcher(dictionary,
+                blockValSet.getDictionaryIdsMV());
+          case LONG:
+            return new DictionaryBasedMVLongValueFetcher(dictionary,
+                blockValSet.getDictionaryIdsMV());
+          case FLOAT:
+            return new DictionaryBasedMVFloatValueFetcher(dictionary,
+                blockValSet.getDictionaryIdsMV());
+          case DOUBLE:
+            return new DictionaryBasedMVDoubleValueFetcher(dictionary,
+                blockValSet.getDictionaryIdsMV());
+          case BOOLEAN:
+          case STRING:
+            return new DictionaryBasedMVStringValueFetcher(dictionary,
+                blockValSet.getDictionaryIdsMV());
+          case BYTES:
+            return new DictionaryBasedMVBytesValueFetcher(dictionary,
+                blockValSet.getDictionaryIdsMV());
+        }
+      }
+    } else {
+      switch (expressionResultMetadata.getDataType()) {
+        case INT:
+          return new SVIntValueFetcher(blockValSet.getIntValuesSV());
+        case LONG:
+          return new SVLongValueFetcher(blockValSet.getLongValuesSV());
+        case FLOAT:
+          return new SVFloatValueFetcher(blockValSet.getFloatValuesSV());
+        case DOUBLE:
+          return new SVDoubleValueFetcher(blockValSet.getDoubleValuesSV());
+        case BOOLEAN:
+        case STRING:
+          return new SVStringValueFetcher(blockValSet.getStringValuesSV());
+        case BYTES:
+          return new SVBytesValueFetcher(blockValSet.getBytesValuesSV());
+      }
+    }
+    throw new UnsupportedOperationException();
+  }
+}
+
+
+interface Fetcher {
+
+  Serializable getValue(int docId);
+}
+
+class SVIntValueFetcher implements Fetcher {
+
+  private int[] _values;
+
+  SVIntValueFetcher(int[] values) {
+    _values = values;
+  }
+
+  public Serializable getValue(int docId) {
+    return _values[docId];
+  }
+}
+
+class SVLongValueFetcher implements Fetcher {
+
+  private long[] _values;
+
+  SVLongValueFetcher(long[] values) {
+    _values = values;
+  }
+
+  public Serializable getValue(int docId) {
+    return _values[docId];
+  }
+}
+
+class SVFloatValueFetcher implements Fetcher {
+
+  private float[] _values;
+
+  SVFloatValueFetcher(float[] values) {
+    _values = values;
+  }
+
+  public Serializable getValue(int docId) {
+    return _values[docId];
+  }
+}
+
+class SVDoubleValueFetcher implements Fetcher {
+
+  private double[] _values;
+
+  SVDoubleValueFetcher(double[] values) {
+    _values = values;
+  }
+
+  public Serializable getValue(int docId) {
+    return _values[docId];
+  }
+}
+
+class SVStringValueFetcher implements Fetcher {
+
+  private String[] _values;
+
+  SVStringValueFetcher(String[] values) {
+    _values = values;
+  }
+
+  public Serializable getValue(int docId) {
+    return _values[docId];
+  }
+}
+
+class SVBytesValueFetcher implements Fetcher {
+
+  private byte[][] _values;
+
+  SVBytesValueFetcher(byte[][] values) {
+    _values = values;
+  }
+
+  public Serializable getValue(int docId) {
+    return _values[docId];
+  }
+}
+
+class DictionaryBasedSVValueFetcher implements Fetcher {
+
+  private Dictionary _dictionary;
+  private int[] _dictionaryIds;
+  private DataType _dataType;
+
+  DictionaryBasedSVValueFetcher(Dictionary dictionary, int[] dictionaryIds,
+      DataType dataType) {
+
+    _dictionary = dictionary;
+    _dictionaryIds = dictionaryIds;
+    _dataType = dataType;
+  }
+
+  public Serializable getValue(int docId) {
+    if (_dataType.equals(FieldSpec.DataType.BYTES)) {
+      return ByteArray.toHexString(_dictionary.getBytesValue(_dictionaryIds[docId]));
+    }
+    return (Serializable) _dictionary.get(_dictionaryIds[docId]);
+  }
+}
+
+
+class DictionaryBasedMVIntValueFetcher implements Fetcher {
+
+  private Dictionary _dictionary;
+  private int[][] _dictionaryIdsArray;
+
+  DictionaryBasedMVIntValueFetcher(Dictionary dictionary, int[][] dictionaryIdsArray) {
+
+    _dictionary = dictionary;
+    _dictionaryIdsArray = dictionaryIdsArray;
+  }
+
+  public Serializable getValue(int docId) {
+    int[] dictIds = _dictionaryIdsArray[docId];
+    int[] values = new int[dictIds.length];
+    for (int i = 0; i < dictIds.length; i++) {
+      int dictId = dictIds[i];
+      values[i] = _dictionary.getIntValue(dictId);
+    }
+    return values;
+  }
+}
+
+class DictionaryBasedMVLongValueFetcher implements Fetcher {
+
+  private Dictionary _dictionary;
+  private int[][] _dictionaryIdsArray;
+
+  DictionaryBasedMVLongValueFetcher(Dictionary dictionary, int[][] dictionaryIdsArray) {
+
+    _dictionary = dictionary;
+    _dictionaryIdsArray = dictionaryIdsArray;
+  }
+
+  public Serializable getValue(int docId) {
+    int[] dictIds = _dictionaryIdsArray[docId];
+    long[] values = new long[dictIds.length];
+    for (int i = 0; i < dictIds.length; i++) {
+      int dictId = dictIds[i];
+      values[i] = _dictionary.getLongValue(dictId);
+    }
+    return values;
+  }
+}
+
+class DictionaryBasedMVFloatValueFetcher implements Fetcher {
+
+  private Dictionary _dictionary;
+  private int[][] _dictionaryIdsArray;
+
+  DictionaryBasedMVFloatValueFetcher(Dictionary dictionary, int[][] dictionaryIdsArray) {
+
+    _dictionary = dictionary;
+    _dictionaryIdsArray = dictionaryIdsArray;
+  }
+
+  public Serializable getValue(int docId) {
+    int[] dictIds = _dictionaryIdsArray[docId];
+    float[] values = new float[dictIds.length];
+    for (int i = 0; i < dictIds.length; i++) {
+      int dictId = dictIds[i];
+      values[i] = _dictionary.getFloatValue(dictId);
+    }
+    return values;
+  }
+}
+
+class DictionaryBasedMVDoubleValueFetcher implements Fetcher {
+
+  private Dictionary _dictionary;
+  private int[][] _dictionaryIdsArray;
+
+  DictionaryBasedMVDoubleValueFetcher(Dictionary dictionary, int[][] dictionaryIdsArray) {
+
+    _dictionary = dictionary;
+    _dictionaryIdsArray = dictionaryIdsArray;
+  }
+
+  public Serializable getValue(int docId) {
+    int[] dictIds = _dictionaryIdsArray[docId];
+    double[] values = new double[dictIds.length];
+    for (int i = 0; i < dictIds.length; i++) {
+      int dictId = dictIds[i];
+      values[i] = _dictionary.getDoubleValue(dictId);
+    }
+    return values;
+  }
+}
+
+class DictionaryBasedMVStringValueFetcher implements Fetcher {
+
+  private Dictionary _dictionary;
+  private int[][] _dictionaryIdsArray;
+
+  DictionaryBasedMVStringValueFetcher(Dictionary dictionary, int[][] dictionaryIdsArray) {
+
+    _dictionary = dictionary;
+    _dictionaryIdsArray = dictionaryIdsArray;
+  }
+
+  public Serializable getValue(int docId) {
+    int[] dictIds = _dictionaryIdsArray[docId];
+    String[] values = new String[dictIds.length];
+    for (int i = 0; i < dictIds.length; i++) {
+      int dictId = dictIds[i];
+      values[i] = _dictionary.getStringValue(dictId);
+    }
+    return values;
+  }
+}
+
+class DictionaryBasedMVBytesValueFetcher implements Fetcher {
+
+  private Dictionary _dictionary;
+  private int[][] _dictionaryIdsArray;
+
+  DictionaryBasedMVBytesValueFetcher(Dictionary dictionary, int[][] dictionaryIdsArray) {
+
+    _dictionary = dictionary;
+    _dictionaryIdsArray = dictionaryIdsArray;
+  }
+
+  public Serializable getValue(int docId) {
+    int[] dictIds = _dictionaryIdsArray[docId];
+    byte[][] values = new byte[dictIds.length][];
+    for (int i = 0; i < dictIds.length; i++) {
+      int dictId = dictIds[i];
+      values[i] = _dictionary.getBytesValue(dictId);
+    }
+    return values;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/TransformOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/TransformOperator.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.operator.transform;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -38,11 +39,13 @@ import org.apache.pinot.core.segment.index.readers.Dictionary;
  * Class for evaluating transform expressions.
  */
 public class TransformOperator extends BaseOperator<TransformBlock> {
+
   private static final String OPERATOR_NAME = "TransformOperator";
 
   private final ProjectionOperator _projectionOperator;
   private final Map<String, DataSource> _dataSourceMap;
   private final Map<TransformExpressionTree, TransformFunction> _transformFunctionMap = new HashMap<>();
+  private final List<TransformExpressionTree> _expressions;
 
   /**
    * Constructor for the class
@@ -51,11 +54,13 @@ public class TransformOperator extends BaseOperator<TransformBlock> {
    * @param expressions Set of expressions to evaluate
    */
   public TransformOperator(@Nonnull ProjectionOperator projectionOperator,
-      @Nonnull Set<TransformExpressionTree> expressions) {
+      @Nonnull List<TransformExpressionTree> expressions) {
     _projectionOperator = projectionOperator;
+    _expressions = expressions;
     _dataSourceMap = projectionOperator.getDataSourceMap();
     for (TransformExpressionTree expression : expressions) {
-      TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+      TransformFunction transformFunction = TransformFunctionFactory
+          .get(expression, _dataSourceMap);
       _transformFunctionMap.put(expression, transformFunction);
     }
   }
@@ -108,5 +113,9 @@ public class TransformOperator extends BaseOperator<TransformBlock> {
   @Override
   public ExecutionStatistics getExecutionStatistics() {
     return _projectionOperator.getExecutionStatistics();
+  }
+
+  public List<TransformExpressionTree> getExpressions() {
+    return _expressions;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/TransformPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/TransformPlanNode.java
@@ -18,16 +18,25 @@
  */
 package org.apache.pinot.core.plan;
 
+import static org.apache.pinot.core.query.selection.SelectionOperatorUtils.getSelectionColumns;
+
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.apache.pinot.common.request.AggregationInfo;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.Selection;
+import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.common.request.transform.TransformExpressionTree;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionType;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
+import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +50,8 @@ public class TransformPlanNode implements PlanNode {
   private final String _segmentName;
   private final ProjectionPlanNode _projectionPlanNode;
   private final Set<String> _projectionColumns = new HashSet<>();
-  private final Set<TransformExpressionTree> _expressionTrees = new HashSet<>();
+  private final Set<TransformExpressionTree> _expressionTrees = new LinkedHashSet<>();
+  private int _maxDocPerNextCall = DocIdSetPlanNode.MAX_DOC_PER_CALL;
 
   /**
    * Constructor for the class
@@ -51,17 +61,19 @@ public class TransformPlanNode implements PlanNode {
    */
   public TransformPlanNode(@Nonnull IndexSegment indexSegment, @Nonnull BrokerRequest brokerRequest) {
     _segmentName = indexSegment.getSegmentName();
-    extractColumnsAndTransforms(brokerRequest);
+    extractColumnsAndTransforms(brokerRequest, indexSegment);
     _projectionPlanNode =
-        new ProjectionPlanNode(indexSegment, _projectionColumns, new DocIdSetPlanNode(indexSegment, brokerRequest));
+        new ProjectionPlanNode(indexSegment, _projectionColumns, new DocIdSetPlanNode(indexSegment, brokerRequest, _maxDocPerNextCall));
   }
 
   /**
    * Helper method to extract projection columns and transform expressions from the given broker request.
    *
    * @param brokerRequest Broker request to process
+   * @param indexSegment
    */
-  private void extractColumnsAndTransforms(@Nonnull BrokerRequest brokerRequest) {
+  private void extractColumnsAndTransforms(@Nonnull BrokerRequest brokerRequest,
+      IndexSegment indexSegment) {
     if (brokerRequest.isSetAggregationsInfo()) {
       for (AggregationInfo aggregationInfo : brokerRequest.getAggregationsInfo()) {
         if (!aggregationInfo.getAggregationType().equalsIgnoreCase(AggregationFunctionType.COUNT.getName())) {
@@ -81,15 +93,35 @@ public class TransformPlanNode implements PlanNode {
         }
       }
     } else {
-      throw new UnsupportedOperationException("Transforms not supported in selection queries.");
-      // TODO: Add transform support.
-      // projectionColumns.addAll(brokerRequest.getSelections().getSelectionColumns());
+//      throw new UnsupportedOperationException("Transforms not supported in selection queries.");
+      Selection selection = brokerRequest.getSelections();
+      // No ordering required, select minimum number of documents
+      if (!selection.isSetSelectionSortSequence()) {
+        _maxDocPerNextCall = Math.min(selection.getOffset() + selection.getSize(), _maxDocPerNextCall);
+      }
+      List<String> expressions = selection.getSelectionColumns();
+      if (expressions.size() == 1 && expressions.get(0).equals("*")) {
+        expressions = new LinkedList<>(indexSegment.getPhysicalColumnNames());
+      }
+      if (selection.getSelectionSortSequence() != null) {
+        for (SelectionSort selectionSort : selection.getSelectionSortSequence()) {
+          String expression = selectionSort.getColumn();
+          if(!expressions.contains(expression)) {
+            expressions.add(expression);
+          }
+        }
+      }
+      for (String expression : expressions) {
+        TransformExpressionTree transformExpressionTree = TransformExpressionTree.compileToExpressionTree(expression);
+        transformExpressionTree.getColumns(_projectionColumns);
+        _expressionTrees.add(transformExpressionTree);
+      }
     }
   }
 
   @Override
   public TransformOperator run() {
-    return new TransformOperator(_projectionPlanNode.run(), _expressionTrees);
+    return new TransformOperator(_projectionPlanNode.run(), new ArrayList<>(_expressionTrees));
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -76,7 +76,7 @@ public class SelectionOperatorUtils {
   private static final DecimalFormatSymbols DECIMAL_FORMAT_SYMBOLS = DecimalFormatSymbols.getInstance(Locale.US);
 
   /**
-   * Expand <code>'SELECT *'</code> to select all columns with {@link IndexSegment}, order all columns alphabatically.
+   * Expand <code>'SELECT *'</code> to select all columns with {@link IndexSegment}, order all columns alphabetically.
    * (Inner segment)
    *
    * @param selectionColumns unexpanded selection columns (may contain '*').
@@ -88,8 +88,6 @@ public class SelectionOperatorUtils {
       @Nonnull IndexSegment indexSegment) {
     if (selectionColumns.size() == 1 && selectionColumns.get(0).equals("*")) {
       List<String> allColumns = new LinkedList<>(indexSegment.getPhysicalColumnNames());
-      Set<String> columnNames = indexSegment.getPhysicalColumnNames();
-
       Collections.sort(allColumns);
       return allColumns;
     } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeTransformPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeTransformPlanNode.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.startree.plan;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -65,7 +66,7 @@ public class StarTreeTransformPlanNode implements PlanNode {
 
   @Override
   public TransformOperator run() {
-    return new TransformOperator(_starTreeProjectionPlanNode.run(), _groupByExpressions);
+    return new TransformOperator(_starTreeProjectionPlanNode.run(), new ArrayList<>(_groupByExpressions));
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/query/aggregation/DefaultAggregationExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/aggregation/DefaultAggregationExecutorTest.java
@@ -138,7 +138,7 @@ public class DefaultAggregationExecutorTest {
     MatchAllFilterOperator matchAllFilterOperator = new MatchAllFilterOperator(totalRawDocs);
     DocIdSetOperator docIdSetOperator = new DocIdSetOperator(matchAllFilterOperator, DocIdSetPlanNode.MAX_DOC_PER_CALL);
     ProjectionOperator projectionOperator = new ProjectionOperator(dataSourceMap, docIdSetOperator);
-    TransformOperator transformOperator = new TransformOperator(projectionOperator, expressionTrees);
+    TransformOperator transformOperator = new TransformOperator(projectionOperator, new ArrayList<>(expressionTrees));
     TransformBlock transformBlock = transformOperator.nextBlock();
     int numAggFuncs = _aggregationInfoList.size();
     AggregationFunctionContext[] aggrFuncContextArray = new AggregationFunctionContext[numAggFuncs];


### PR DESCRIPTION
We currently support expressions and udf's in aggregation and group by but not in selection and filters. This PR adds support for expressions in selection.

Note that with this PR, we add the support in query execution but the pql parsing does not support it. All udfs in select list are treated as aggregation functions by default. The reason is that AggregationFunctionType is in pinot-core, we will have to move it to pinot-common so that we can check for the name and decide if its a simple function vs aggregation function. Will add that in another PR.

Existing test cases passed. 
