### PR TITLE
Adding support to ingest Map and MapValueTransform Factory

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MapValueTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MapValueTransformFunction.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.apache.pinot.core.common.DataSource;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.core.segment.index.readers.Dictionary;
+
+
+/**
+ * map_value(keyColName, 'keyName', valColName)
+ */
+public class MapValueTransformFunction extends BaseTransformFunction {
+
+  public static final String FUNCTION_NAME = "map_value";
+
+  private TransformResultMetadata _resultMetadata;
+  private TransformFunction _keyColumnFunction;
+  private String _keyName;
+  private TransformFunction _valueColumnFunction;
+  private int[][] _keyDictIds;
+  private int[][] _valueDictIds;
+  private int _inputKeyDictId;
+  private int[] _outputValueDictIds;
+
+  @Override
+  public String getName() {
+    return FUNCTION_NAME;
+  }
+
+  @Override
+  public void init(@Nonnull List<TransformFunction> arguments, @Nonnull Map<String, DataSource> dataSourceMap) {
+    _keyColumnFunction = arguments.get(0);
+    _keyName = ((LiteralTransformFunction) arguments.get(1)).getLiteral();
+    _valueColumnFunction = arguments.get(2);
+    TransformResultMetadata valueColumnMetadata = _valueColumnFunction.getResultMetadata();
+    _resultMetadata =
+        new TransformResultMetadata(valueColumnMetadata.getDataType(), true, valueColumnMetadata.hasDictionary());
+    _inputKeyDictId = _keyColumnFunction.getDictionary().indexOf(_keyName);
+  }
+
+  @Override
+  public TransformResultMetadata getResultMetadata() {
+    return _resultMetadata;
+  }
+
+  @Override
+  public int[] transformToDictIdsSV(@Nonnull ProjectionBlock projectionBlock) {
+    _outputValueDictIds = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+
+    _keyDictIds = _keyColumnFunction.transformToDictIdsMV(projectionBlock);
+    _valueDictIds = _valueColumnFunction.transformToDictIdsMV(projectionBlock);
+    int length = projectionBlock.getNumDocs();
+    for (int i = 0; i < length; i++) {
+      int numKeys = _keyDictIds[i].length;
+      for (int j = 0; j < numKeys; j++) {
+        if (_keyDictIds[i][j] == _inputKeyDictId) {
+          _outputValueDictIds[i] = _valueDictIds[i][j];
+          break;
+        }
+      }
+    }
+    return _outputValueDictIds;
+  }
+
+  @Override
+  public Dictionary getDictionary() {
+    return _valueColumnFunction.getDictionary();
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -48,6 +48,7 @@ public class TransformFunctionFactory {
           put(DateTimeConversionTransformFunction.FUNCTION_NAME.toLowerCase(),
               DateTimeConversionTransformFunction.class);
           put(ValueInTransformFunction.FUNCTION_NAME.toLowerCase(), ValueInTransformFunction.class);
+          put(MapValueTransformFunction.FUNCTION_NAME.toLowerCase(), MapValueTransformFunction.class);
         }
       };
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
@@ -38,7 +38,8 @@ import org.slf4j.LoggerFactory;
 public class SelectionPlanNode implements PlanNode {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SelectionPlanNode.class);
-  public static boolean enableUDFInSelection = false;
+  //temporary
+  public static boolean enableUDFInSelection = Boolean.valueOf(System.getProperty("enableUDFInSelection"));
   private final IndexSegment _indexSegment;
   private final Selection _selection;
   private TransformPlanNode _transformPlanNode;

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentDictionaryCreator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/creator/impl/SegmentDictionaryCreator.java
@@ -268,7 +268,7 @@ public class SegmentDictionaryCreator implements Closeable {
         throw new UnsupportedOperationException("Unsupported data type : " + _fieldSpec.getDataType());
     }
 
-    Arrays.sort(indexes);
+//    Arrays.sort(indexes);
     return indexes;
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ValueInTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ValueInTransformFunctionTest.java
@@ -54,8 +54,6 @@ public class ValueInTransformFunctionTest extends BaseTransformFunctionTest {
         }
       }
       int[] expectedValues = expectedList.toIntArray();
-      // NOTE: need to sort the expected array because we sort the dictionary Ids for multi-valued entries
-      Arrays.sort(expectedValues);
 
       int numValues = expectedValues.length;
       for (int j = 0; j < numValues; j++) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MapTypeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MapTypeClusterIntegrationTest.java
@@ -1,0 +1,222 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements.  See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the License.  You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nonnull;
+
+import org.apache.avro.Schema.Field;
+import org.apache.avro.Schema.Type;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.data.DimensionFieldSpec;
+import org.apache.pinot.common.data.FieldSpec;
+import org.apache.pinot.common.data.FieldSpec.DataType;
+import org.apache.pinot.common.data.Schema;
+import org.apache.pinot.common.utils.JsonUtils;
+import org.apache.pinot.core.indexsegment.generator.SegmentVersion;
+import org.apache.pinot.tools.data.generator.AvroWriter;
+import org.apache.pinot.tools.query.comparison.StarTreeQueryGenerator;
+import org.apache.pinot.util.TestUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.Lists;
+
+
+public class MapTypeClusterIntegrationTest extends BaseClusterIntegrationTest {
+
+  protected static final String DEFAULT_TABLE_NAME = "myTable";
+  static final long TOTAL_DOCS = 1_000L;
+
+  protected Schema _schema;
+  private StarTreeQueryGenerator _queryGenerator;
+  private String _currentTable;
+
+  @Nonnull
+  @Override
+  protected String getTableName() {
+    return _currentTable;
+  }
+
+  @Nonnull
+  @Override
+  protected String getSchemaFileName() {
+    return null;
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir);
+
+    // Start the Pinot cluster
+    startZk();
+    startController();
+    startBroker();
+    startServers(1);
+
+    _schema = new Schema();
+    FieldSpec keyFieldSpec = new DimensionFieldSpec();
+    keyFieldSpec.setDataType(DataType.STRING);
+    keyFieldSpec.setDefaultNullValue("");
+    keyFieldSpec.setName("myMap__KEYS");
+    keyFieldSpec.setSingleValueField(false);
+    _schema.addField(keyFieldSpec);
+    FieldSpec valueFieldSpec = new DimensionFieldSpec();
+    valueFieldSpec.setDataType(DataType.STRING);
+    valueFieldSpec.setDefaultNullValue("");
+    valueFieldSpec.setName("myMap__VALUES");
+    valueFieldSpec.setSingleValueField(false);
+    _schema.addField(valueFieldSpec);
+
+    // Create the tables
+    ArrayList<String> invertedIndexColumns = Lists.newArrayList();
+    addOfflineTable(DEFAULT_TABLE_NAME, null, null, null, null, null, SegmentVersion.v1, invertedIndexColumns, null,
+        null);
+
+    setUpSegmentsAndQueryGenerator();
+
+    // Wait for all documents loaded
+    _currentTable = DEFAULT_TABLE_NAME;
+    waitForAllDocsLoaded(10_000);
+  }
+
+  @Override
+  protected long getCountStarResult() {
+    return TOTAL_DOCS;
+  }
+
+  protected void setUpSegmentsAndQueryGenerator()
+      throws Exception {
+
+    org.apache.avro.Schema mapAvroSchema = org.apache.avro.Schema.createMap(org.apache.avro.Schema.create(Type.STRING));
+    List<Field> fields = new ArrayList<>();
+    fields.add(new Field("myMap", mapAvroSchema, "", null));
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("myRecord", "some desc", null, false);
+    avroSchema.setFields(fields);
+
+    DataFileWriter recordWriter = new DataFileWriter<>(new GenericDatumWriter<GenericData.Record>(avroSchema));
+    String parent = "/tmp/mapTest";
+    File avroFile = new File(parent, "part-" + 0 + ".avro");
+    avroFile.getParentFile().mkdirs();
+    recordWriter.create(avroSchema, avroFile);
+    for (int i = 0; i < TOTAL_DOCS; i++) {
+      Map<String, String> map = new HashMap<>();
+      map.put("k1", "value-k1-" + i);
+      map.put("k2", "value-k2-" + i);
+      GenericData.Record record = new GenericData.Record(avroSchema);
+      record.put("myMap", map);
+      recordWriter.append(record);
+    }
+    recordWriter.close();
+
+    // Unpack the Avro files
+    List<File> avroFiles = Lists.newArrayList(avroFile);
+
+    // Create and upload segments without star tree indexes from Avro data
+    createAndUploadSegments(avroFiles, DEFAULT_TABLE_NAME, false);
+  }
+
+  private void createAndUploadSegments(List<File> avroFiles, String tableName, boolean createStarTreeIndex)
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_segmentDir, _tarDir);
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    ClusterIntegrationTestUtils
+        .buildSegmentsFromAvro(avroFiles, 0, _segmentDir, _tarDir, tableName, createStarTreeIndex, null, null, _schema,
+            executor);
+    executor.shutdown();
+    executor.awaitTermination(10, TimeUnit.MINUTES);
+
+    uploadSegments(_tarDir);
+  }
+
+  @Test
+  public void testQueries()
+      throws Exception {
+    //Group By Query
+    String pqlQuery =
+        "Select count(*) from " + DEFAULT_TABLE_NAME + " group by map_value(myMap__KEYS, 'k1', myMap__VALUES)";
+    JsonNode pinotResponse = postQuery(pqlQuery);
+    System.out.println("pinotResponse = " + pinotResponse);
+    Assert.assertNotNull(pinotResponse.get("aggregationResults"));
+    JsonNode groupByResult = pinotResponse.get("aggregationResults").get(0).get("groupByResult");
+    Assert.assertNotNull(groupByResult);
+    Assert.assertTrue(groupByResult.isArray());
+    Assert.assertTrue(groupByResult.size() > 0);
+
+    //Selection Query
+    pqlQuery = "Select map_value(myMap__KEYS, 'k1', myMap__VALUES) from " + DEFAULT_TABLE_NAME ;
+    pinotResponse = postQuery(pqlQuery);
+    System.out.println("pinotResponse = " + pinotResponse);
+
+    pqlQuery = "Select map_value(myMap__KEYS, 'k1', myMap__VALUES) from " + DEFAULT_TABLE_NAME  + " order by map_value(myMap__KEYS, 'k1', myMap__VALUES)" ;
+    pinotResponse = postQuery(pqlQuery);
+    System.out.println("pinotResponse = " + pinotResponse);
+
+
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    dropOfflineTable(DEFAULT_TABLE_NAME);
+
+    stopServer();
+    stopBroker();
+    stopController();
+    stopZk();
+
+    FileUtils.deleteDirectory(_tempDir);
+  }
+}


### PR DESCRIPTION
Supporting Map as a DataType was bit invasive and requires us to first introduce the concept of CompositeColumnDatasource. 

While this solution is not elegant, it is a good first step towards supporting Map and Struct data types.

This leverages existing features MultiValue feature in Pinot. A Map is represented as two Multi-valued columns - <mapColumn>__KEYS and <mapColumn>__VALUES. This convention is used in only one place - real-time ingestion and segment generation. When pinot sees a FieldSpec name that ends with __KEYS or __VALUES it checks for <mapColumn>field in the input Record. If that object turns out to be a map, then we convert it into two columns -> keyArray and valueArray.

Once we have this, we just need to support a transformUDF map_value(keyColumnName, 'KeyName', valueColumnName) which is equivalent of map['keyName']. We can support the simpler syntax in another PR.

Sample queries 

```select map_value(myMap__KEYS, 'k1', myMap__VALUES) from myTable```

```select count(*) from myTable group by map_value(myMap__KEYS, 'k1', myMap__VALUES)```

